### PR TITLE
Fix the links to playbooks.

### DIFF
--- a/.github/workflows/ctlog-sth.yml
+++ b/.github/workflows/ctlog-sth.yml
@@ -76,7 +76,7 @@ jobs:
       links: >
         [
           {
-            "href": "https://github.com/sigstore/sigstore-probers/blob/main/playbooks/alerting/alerts/ct-log-uptime-failure.md",
+            "href": "https://github.com/sigstore/public-good-instance/blob/main/playbooks/alerting/alerts/ct-log-uptime-failure.md",
             "text": "CTFE Prober Failure Playbook"
           }
         ]

--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -240,7 +240,7 @@ jobs:
         run: |
           cosign sign --force ${IMAGE} --rekor-url  ${{ inputs.rekor_url }} --fulcio-url ${{ inputs.fulcio_url }} --oidc-issuer ${{ inputs.oidc_url }}
           cosign verify ${IMAGE} --rekor-url  ${{ inputs.rekor_url }}
-          
+
       - name: Remove preprod TUF
         if: ${{ inputs.enable_staging == false }}
         run: |
@@ -340,7 +340,7 @@ jobs:
       links: >
         [
           {
-            "href": "https://github.com/sigstore/sigstore-probers/blob/main/playbooks/alerting/alerts/k8s-api-endpoint-prober.md",
+            "href": "https://github.com/sigstore/public-good-instance/blob/main/playbooks/alerting/alerts/k8s-api-endpoint-prober.md",
             "text": "Prober Failure Playbook"
           }
         ]


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
The pagerduty has the incorrect links coming to sigstore-probers instead of p-g-i.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
* Fix the links to playbooks.

<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->