### PR TITLE
Use retry action for prober

### DIFF
--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 3
-          retry_wait_seconds: 10
+          retry_wait_seconds: 60
           retry_on: error
           command: prober --one-time --rekor-url ${{ inputs.rekor_url }} --fulcio-url ${{ inputs.fulcio_url }}
 

--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Run prober
         env:
           DEBUG: 1
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
         with:
           timeout_seconds: 15
           max_attempts: 3

--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -87,7 +87,12 @@ jobs:
       - name: Run prober
         env:
           DEBUG: 1
-        run: prober --one-time --rekor-url ${{ inputs.rekor_url }} --fulcio-url ${{ inputs.fulcio_url }}
+        uses: nick-fields/retry@v2
+        with:
+          timeout_seconds: 15
+          max_attempts: 3
+          retry_on: error
+          command: prober --one-time --rekor-url ${{ inputs.rekor_url }} --fulcio-url ${{ inputs.fulcio_url }}
 
       - name: Set messages
         id: msg

--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -89,8 +89,9 @@ jobs:
           DEBUG: 1
         uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
         with:
-          timeout_seconds: 15
+          timeout_minutes: 5
           max_attempts: 3
+          retry_wait_seconds: 10
           retry_on: error
           command: prober --one-time --rekor-url ${{ inputs.rekor_url }} --fulcio-url ${{ inputs.fulcio_url }}
 

--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -89,7 +89,7 @@ jobs:
           DEBUG: 1
         uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 60
           retry_on: error


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Closes https://github.com/sigstore/public-good-instance/issues/1113

Let's try using a [Github Action for retrying a specific job](https://github.com/marketplace/actions/retry-step) to hopefully address some occasionally flakiness we see in the GHA environment. Occasionally the `sigstore-prober` job step will fail because it cannot find a variable that should be available in the GHA environment. The job runs as expected when we manually retry it.

By allowing retries on the sigstore-prober job, we can hopefully avoid alerting on this occasional flakiness and only alert on repeated failures.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->