### PR TITLE
add test of staging tuf repo via CDN

### DIFF
--- a/.github/workflows/prober-staging-cdn.yml
+++ b/.github/workflows/prober-staging-cdn.yml
@@ -1,0 +1,36 @@
+name: Staging CDN Sigstore Prober
+
+on:
+  workflow_dispatch:
+    inputs:
+      triggerPagerDutyTest:
+        description: 'Trigger PagerDuty test message'
+        required: false
+        type: boolean
+  schedule:
+    # run every 15 minutes, as often as Github Actions allows
+    - cron:  '0/15 * * * *'
+
+permissions:
+  id-token: write
+  contents: read
+  packages: write
+
+jobs:
+  prober:
+    uses: ./.github/workflows/reusable-prober.yml
+    secrets:
+      PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    with:
+      enable_staging: true
+      rekor_url: "https://rekor.sigstage.dev"
+      fulcio_url: "https://fulcio.sigstage.dev"
+      oidc_url: "https://oauth2.sigstage.dev/auth"
+      tuf_repo: "https://tuf-repo-cdn.sigstage.dev"
+      tuf_preprod_repo: "https://tuf-repo-cdn.sigstage.dev/preprod/"
+      tuf_root_url: "https://tuf-repo-cdn.sigstage.dev/root.json"
+      triggerPagerDutyTest: ${{ github.event.inputs.triggerPagerDutyTest }}

--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Check expiration
         run: |
           if [ "${{ inputs.tuf_root_url }}" != "" ]; then
-            curl -Lo root.json ${{ inputs.tuf_root_url }}
+            curl -Lo root.json --user-agent "sigstore-prober" ${{ inputs.tuf_root_url }}
             export ROOT_PATH=root.json
           else
             export ROOT_PATH=$GITHUB_WORKSPACE/root-signing/${{ inputs.tuf_root_path }}
@@ -230,7 +230,7 @@ jobs:
       - name: Initialize preprod TUF root
         if: ${{ inputs.enable_staging == false }}
         run: |
-          curl -Lo root.json ${{ inputs.tuf_preprod_repo }}/root.json
+          curl -Lo root.json --user-agent "sigstore-prober" ${{ inputs.tuf_preprod_repo }}/root.json
           for i in {1..5}
           do
             if cosign initialize --mirror=${{ inputs.tuf_preprod_repo }} --root=root.json; then
@@ -271,7 +271,7 @@ jobs:
           curl -Lo root.json ${{ inputs.tuf_root_url }}
           for i in {1..5}
           do
-            if cosign initialize --mirror=https://tuf-root-staging.storage.googleapis.com --root=root.json; then
+            if cosign initialize --mirror=${{ inputs.tuf_repo }} --root=root.json; then
               echo "Successfully initialized" && exit 0
             else
               echo "Failed to initialize" && sleep 10


### PR DESCRIPTION
This adds a test to observe behavior of fetching the staging TUF root via a Cloud CDN endpoint.