### PR TITLE
reenable cache, ensure all runners use same OS version

### DIFF
--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -63,20 +63,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v3.3.0
         with:
-          go-version: 1.19
+          go-version-file: 'prober/hack/toolz/go.mod'
           check-latest: true
-
-      - name: Use module cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        timeout-minutes: 10
-        continue-on-error: true
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ github.job }}-${{ hashFiles('**/go.sum', '/go.work.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache-dependency-path: 'prober/hack/tools/go.sum'
 
       - name: Install 'prober' from sigstore/scaffolding
         run: |
@@ -104,7 +93,7 @@ jobs:
 
 
   root-probe:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       root_state: ${{ steps.msg.outputs.root_state }}
     steps:
@@ -118,19 +107,9 @@ jobs:
           path: root-signing
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v3.3.0
         with:
-          go-version: 1.19
+          go-version-file: 'prober/hack/toolz/go.mod'
           check-latest: true
-#      - name: Use module cache
-#        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-#        timeout-minutes: 10
-#        continue-on-error: true
-#        with:
-#          path: |
-#            ~/.cache/go-build
-#            ~/go/pkg/mod
-#          key: ${{ runner.os }}-go-${{ github.job }}-${{ hashFiles('**/go.sum', '/go.work.sum') }}
-#          restore-keys: |
-#            ${{ runner.os }}-go-
+          cache-dependency-path: 'prober/hack/tools/go.sum'
 
       - name: Install 'verify' tool from sigstore/root-signing
         run: |
@@ -187,19 +166,9 @@ jobs:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v3.3.0
         with:
-          go-version: 1.19
+          go-version-file: 'prober/hack/toolz/go.mod'
           check-latest: true
-      - name: Use module cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        timeout-minutes: 10
-        continue-on-error: true
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ github.job }}-${{ hashFiles('**/go.sum', '/go.work.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache-dependency-path: 'prober/hack/tools/go.sum'
 
       # Install crane / rekor-cli / cosign tools
       - name: Install (crane, rekor-cli, cosign) tools

--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           go-version-file: 'prober/hack/toolz/go.mod'
           check-latest: true
-          cache-dependency-path: 'prober/hack/tools/go.sum'
+          cache-dependency-path: 'prober/hack/toolz/go.sum'
 
       - name: Install 'prober' from sigstore/scaffolding
         run: |
@@ -109,7 +109,7 @@ jobs:
         with:
           go-version-file: 'prober/hack/toolz/go.mod'
           check-latest: true
-          cache-dependency-path: 'prober/hack/tools/go.sum'
+          cache-dependency-path: 'prober/hack/toolz/go.sum'
 
       - name: Install 'verify' tool from sigstore/root-signing
         run: |
@@ -168,7 +168,7 @@ jobs:
         with:
           go-version-file: 'prober/hack/toolz/go.mod'
           check-latest: true
-          cache-dependency-path: 'prober/hack/tools/go.sum'
+          cache-dependency-path: 'prober/hack/toolz/go.sum'
 
       # Install crane / rekor-cli / cosign tools
       - name: Install (crane, rekor-cli, cosign) tools


### PR DESCRIPTION
https://github.com/sigstore/sigstore-probers/actions/runs/4075935157 failed on an upgrade to go.mod, but the underlying issue was that the cache was created on `ubuntu-latest` but one of the jobs was instructed to run on `ubuntu-20.04`. This created a GLIBC mismatch when compiling against Ubuntu 22 and then trying to execute on Ubuntu 20. 

This changes PR all jobs to use the same OS image, and also makes some tweaks to use the cache from `actions/setup-go` and set the go version to be used from the `prober/hack/toolz/go.mod` file.

This should make probers faster 🤞🏼 