### PR TITLE
optimization: separate caches by job

### DIFF
--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -61,11 +61,21 @@ jobs:
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v3.3.0
         with:
           go-version-file: 'prober/hack/toolz/go.mod'
           check-latest: true
-          cache-dependency-path: 'prober/hack/toolz/go.sum'
+          cache: false
+
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-${{ github.job }}-${{ hashFiles('prober/hack/toolz/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-${{ github.job }}-
 
       - name: Install 'prober' from sigstore/scaffolding
         run: |
@@ -106,10 +116,20 @@ jobs:
           ref: main
           path: root-signing
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v3.3.0
+        id: setup-go
         with:
           go-version-file: 'prober/hack/toolz/go.mod'
           check-latest: true
-          cache-dependency-path: 'prober/hack/toolz/go.sum'
+          cache: false
+
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-${{ github.job }}-${{ hashFiles('prober/hack/toolz/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-${{ github.job }}-
 
       - name: Install 'verify' tool from sigstore/root-signing
         run: |
@@ -165,10 +185,20 @@ jobs:
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v3.3.0
+        id: setup-go
         with:
           go-version-file: 'prober/hack/toolz/go.mod'
           check-latest: true
-          cache-dependency-path: 'prober/hack/toolz/go.sum'
+          cache: false
+
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-${{ github.job }}-${{ hashFiles('prober/hack/toolz/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-${{ github.job }}-
 
       # Install crane / rekor-cli / cosign tools
       - name: Install (crane, rekor-cli, cosign) tools


### PR DESCRIPTION
#### Summary

https://github.com/sigstore/sigstore-probers/pull/48 re-enabled caching to improve prober job times. However, the cache feature within actions/setup-go does not provide the ability to customize the caching key, so we end up in a suboptimal situation where the cache only contains a subset of what is needed for each job. This PR separates into per-job caches which should provide appropriate isolation as well as improved latency.