### PR TITLE
fix: add a timeout of 10 minutes to the probers

### DIFF
--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -55,6 +55,7 @@ jobs:
 
   sigstore-probe:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     outputs:
       sigstore_probe: ${{ steps.msg.outputs.sigstore_probe }}
@@ -103,6 +104,7 @@ jobs:
 
 
   root-probe:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     outputs:
       root_state: ${{ steps.msg.outputs.root_state }}


### PR DESCRIPTION
Closes: #1398

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

There is not timeout set for those jobs, and by default github sets it to 360 minutes. It means that any step that is stuck will cause this to run for 6 hours.

Adding a more sane timeout of 10 minutes to ensure that the job is completed on time, or abort if not.

#### Release Note

NONE

#### Documentation

None, it is a change on the CI
