### PR TITLE
Add timeout to CT log prober

### DIFF
--- a/.github/workflows/ctlog-sth.yml
+++ b/.github/workflows/ctlog-sth.yml
@@ -15,6 +15,7 @@ jobs:
   ctlog-sth:
     name: CTLog STH probe
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     outputs:
       summary: ${{ steps.ctlog_sth_probe.outputs.summary }}
       probe_status: ${{ steps.ctlog_sth_probe.outputs.probe_status }}


### PR DESCRIPTION
each job usually takes 10 seconds so 2 minutes should be more than enough time.

