### PR TITLE
Create github issues for alerts

### DIFF
--- a/.github/workflows/prober-prod.yml
+++ b/.github/workflows/prober-prod.yml
@@ -21,6 +21,7 @@ jobs:
     uses: ./.github/workflows/reusable-prober.yml
     secrets:
       PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+      sigstore_github_token: ${{ secrets.SIGSTORE_BOT_PAT }}
     with:
       tuf_root_path: "ceremony/2022-05-10/repository/root.json"
       triggerPagerDutyTest: ${{ github.event.inputs.triggerPagerDutyTest }}

--- a/.github/workflows/prober-staging.yml
+++ b/.github/workflows/prober-staging.yml
@@ -21,6 +21,7 @@ jobs:
     uses: ./.github/workflows/reusable-prober.yml
     secrets:
       PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
+      sigstore_github_token: ${{ secrets.SIGSTORE_BOT_PAT }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -6,6 +6,9 @@ on:
       PAGERDUTY_INTEGRATION_KEY:
         description: 'Integration key for PagerDuty'
         required: true
+      sigstore_github_token:
+        description: 'Personal Access Token for GitHub. Must have permission to create issues with labels in the repo specified in github_issues_repo.'
+        required: true
     inputs:
       rekor_url:
         required: false
@@ -47,6 +50,11 @@ on:
         description: 'Trigger PagerDuty test message'
         required: false
         type: string
+      github_issues_repo:
+        required: false
+        type: string
+        default: 'sigstore/public-good-instance'
+        description: 'GitHub repo to file alert issues under'
 
 permissions:
   contents: read
@@ -388,3 +396,26 @@ jobs:
             "text": "Expiring TUF Metadata Playbook"
           }
         ]
+
+  github-issue:
+    if: always() && (needs.sigstore-probe.result == 'failure' || needs.root-probe.result == 'failure' || needs.rekor-fulcio-e2e.result == 'failure')
+    runs-on: ubuntu-latest
+    needs: [sigstore-probe, root-probe, rekor-fulcio-e2e, compute-summary-msg]
+    steps:
+      - uses: actions-ecosystem/action-create-issue@b02a3c1d9d929a5839315bd255e40389f0dab627 # v1.0.0
+        with:
+          github_token: ${{ secrets.sigstore_github_token }}
+          repo: ${{ inputs.github_issues_repo }}
+          title: "[ALERT][${{ needs.compute-summary-msg.outputs.group }}] Prober Failed"
+          body: |
+            Environment: ${{ needs.compute-summary-msg.outputs.group }}
+            Failure URL: https://github.com/sigstore/sigstore-probers/actions/runs/${{ github.run_id }}
+            Commit: ${{ github.sha }}
+            Prober: ${{ needs.sigstore-probe.outputs.sigstore_probe }}
+            GCS Root: ${{ needs.root-probe.outputs.root_state }}
+            Rekor Fulcio E2E Test: ${{ needs.rekor-fulcio-e2e.outputs.rekor_fulcio_e2e }}
+          labels: |
+            needs-assignee
+            alert
+            oncall
+            ${{ inputs.enable_staging && 'env:staging' || 'env:production' }}


### PR DESCRIPTION
Add a job to the reusable prober workflow to create an issue in sigstore/public-good-instance when one of the probes fails.

The new job needs a new input, SIGSTORE_BOT_PAT, configured as a secret for the sigstore/sigstore-probers repo. The PAT needs to belong to a user or bot that has permission to create issues with labels for sigstore/public-good-instance.

The new job creates the issue with a new `needs-assignee` label. A sibling job in sigstore/public-good-instance will react to new issues that have this label and add the active oncall engineer as the assignee.

Relates to https://github.com/sigstore/public-good-instance/issues/486
Depends on https://github.com/sigstore/community/pull/377