### PR TITLE
Add replacement actions for create-issue

### DIFF
--- a/.github/actions/close-workflow-issue/action.yml
+++ b/.github/actions/close-workflow-issue/action.yml
@@ -1,0 +1,57 @@
+name: Close workflow issue
+description: Close a GitHub issue opened by open-workflow-issue
+# The issue is identified by it's title which is built from
+# the workflow name: make sure the workflow name is unique enough
+#
+# Required permissions:
+# * issues: write
+# * actions: read
+
+runs:
+  using: "composite"
+  steps:
+    - name: Close issue
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      with:
+        script: |
+          var path = require('path');
+
+          const reponame = context.repo.owner + "/" + context.repo.repo
+          const title = `[bug]: Workflow failure '${context.workflow}'`
+          const workflow_file = path.basename(context.payload.workflow)
+          const issues = await github.rest.search.issuesAndPullRequests({
+            q:  `${title}+in:title+label:bug+state:open+type:issue+repo:${reponame}`,
+          })
+
+          const run = await github.rest.actions.getWorkflowRun( {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: context.runId,
+          })
+
+          if (issues.data.total_count == 0) {
+            console.log("No issues found, exiting")
+          } else {
+            issue = issues.data.items[0].number
+            console.log(`issue ${issue} found, closing issue`)
+
+            body = `### Closing issue based on workflow '${context.workflow}' success.\n` +
+                   `Run: ${run.data.html_url}\n` +
+                   `Workflow: ${run.data.repository.html_url}/blob/${context.payload.ref}/${run.data.path}\n` +
+                   `Workflow runs: ${run.data.repository.html_url}/actions/workflows/${workflow_file}\n` +
+                   `Trigger: ${context.eventName} on ${context.payload.ref}\n` +
+                   `Date: ${run.data.run_started_at}`
+
+            await github.rest.issues.createComment({
+              issue_number: issue,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })
+            await github.rest.issues.update({
+              issue_number: issue,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "closed",
+            })
+          }

--- a/.github/actions/open-workflow-issue/action.yml
+++ b/.github/actions/open-workflow-issue/action.yml
@@ -1,0 +1,67 @@
+name: Open workflow issue
+description: Open a github issue for a workflow failure
+# An issue is filed unless one for the same workflow is open already.
+# The issues are identitied by title which is built using the workflow
+# name.
+#
+# Required permissions:
+# * issues: write
+# * actions: read
+
+inputs:
+  comment_for_each_failure:
+    description: 'Should a comment be added to existing issue for every new failure'
+    required: false
+    default: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create issue
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      with:
+        script: |
+          var path = require('path');
+
+          const reponame = context.repo.owner + "/" + context.repo.repo
+          const title = `[bug]: Workflow failure '${context.workflow}'`
+          const workflow_file = path.basename(context.payload.workflow)
+          const issues = await github.rest.search.issuesAndPullRequests({
+            q:  `${title}+in:title+label:bug+state:open+type:issue+repo:${reponame}`,
+          })
+
+          const run = await github.rest.actions.getWorkflowRun( {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: context.runId,
+          })
+
+          body = `### Workflow run failed for '${context.workflow}'.\n` +
+                 `Run: ${run.data.html_url}\n` +
+                 `Workflow: ${run.data.repository.html_url}/blob/${context.payload.ref}/${run.data.path}\n` +
+                 `Workflow runs: ${run.data.repository.html_url}/actions/workflows/${workflow_file}\n` +
+                 `Trigger: ${context.eventName} on ${context.payload.ref}\n` +
+                 `Date: ${run.data.run_started_at}`
+
+          if (issues.data.total_count == 0) {
+            console.log("Filing new issue for failing workflow...")
+            await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                labels: ["bug"],
+                body: body,
+              })
+          } else if (${{ inputs.comment_for_each_failure }}) {
+            issue = issues.data.items[0].number
+            console.log(`issue ${issue} found, adding a comment`)
+            await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue,
+                body: body,
+              })
+          } else {
+            issue = issues.data.items[0].number
+            console.log(`issue ${issue} found, not adding a comment`)
+          }


### PR DESCRIPTION
## Summary 
actions/create-issue is used by root-signing and the private repo to file issues in those same repos based on workflow failures. It currently uses a bash script that in turn uses curl, tr, cut, rev, jq, sed and gh to manipulate the GitHub API: this seems quite fragile and is currently broken in private repos (curl authentication problem).

This commit adds two new actions open-workflow-issue, close-workflow-issue that should provide the same minimal functionality using javascript (a composite action that uses github-script).

Intent (if this is merged) is to
* update both root-signing and private repo to use these instead of create-issue
* after that remove actions/create-issue and scripts/create_issue.sh

Fixes #158 

## Decisions to make

1. We could just fix the curl authentication that is the current issue with a one-liner instead and let create-issue be...
1. Does maintaining actions like this even make sense -- should we just use a 3rd party action (like workflows/reusable-prober.yml in this repo already does) instead?

My opinion: It's a close call but I think this might just be worth it:  The new scripts may naturally have bugs but they should be quite a bit easier to understand and fix. 

## Notes

* I tried to keep the actions as simple as possible: if they become complex, then I think it makes sense to use a 3rd party action instead
* There are two actions instead of one because create-issue usage is confusing: it is hard to see if it was actually opening or closing an issue
* these are composite actions instead of js actions just to keep them as simple as possible (no npm lockfiles etc)
* I've tested these in a separate repository: the output is not 1:1 to create-issue output but it's very close: https://github.com/jku/create-issue-tester/issues/5