### PR TITLE
Issue actions: fix workflow path use

### DIFF
--- a/.github/actions/close-workflow-issue/action.yml
+++ b/.github/actions/close-workflow-issue/action.yml
@@ -18,7 +18,6 @@ runs:
 
           const reponame = context.repo.owner + "/" + context.repo.repo
           const title = `[bug]: Workflow failure '${context.workflow}'`
-          const workflow_file = path.basename(context.payload.workflow)
           const issues = await github.rest.search.issuesAndPullRequests({
             q:  `${title}+in:title+label:bug+state:open+type:issue+repo:${reponame}`,
           })
@@ -28,6 +27,7 @@ runs:
             repo: context.repo.repo,
             run_id: context.runId,
           })
+          const workflow_file = path.basename(run.data.path)
 
           if (issues.data.total_count == 0) {
             console.log("No issues found, exiting")

--- a/.github/actions/open-workflow-issue/action.yml
+++ b/.github/actions/open-workflow-issue/action.yml
@@ -25,7 +25,6 @@ runs:
 
           const reponame = context.repo.owner + "/" + context.repo.repo
           const title = `[bug]: Workflow failure '${context.workflow}'`
-          const workflow_file = path.basename(context.payload.workflow)
           const issues = await github.rest.search.issuesAndPullRequests({
             q:  `${title}+in:title+label:bug+state:open+type:issue+repo:${reponame}`,
           })
@@ -35,6 +34,7 @@ runs:
             repo: context.repo.repo,
             run_id: context.runId,
           })
+          const workflow_file = path.basename(run.data.path)
 
           body = `### Workflow run failed for '${context.workflow}'.\n` +
                  `Run: ${run.data.html_url}\n` +


### PR DESCRIPTION
Fix a bug in the workflow issue handling: Some webhook payloads do not have a `workflow` field. Use `run.data.path` instead.