### PR TITLE
Switch the preprod TUF url

### DIFF
--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -33,8 +33,8 @@ on:
       tuf_preprod_repo:
         required: false
         type: string
-        default: 'https://tuf-preprod-repo-cdn.sigstore.dev'
-        description: 'TUF Repo'
+        default: 'https://sigstore.github.io/root-signing'
+        description: 'Preprod TUF Repo'
       tuf_root_path:
         required: false
         type: string


### PR DESCRIPTION
root-signing migration to tuf-on-ci tooling means the preprod repository is now published to the projects GitHub Pages url. Otherwise the functionality is the same.

Timeline:
* this should be merged after root-signing has switched to tuf-on-ci (https://github.com/sigstore/root-signing/pull/1323 merge). EDIT: merge is done, all looks good
* publishing to prod (https://github.com/sigstore/root-signing/issues/1340) should be switched on after this PR merges