### PR TITLE
add fulcio grpc url

### DIFF
--- a/.github/workflows/prober-staging.yml
+++ b/.github/workflows/prober-staging.yml
@@ -29,6 +29,7 @@ jobs:
       enable_staging: true
       rekor_url: "https://rekor.sigstage.dev"
       fulcio_url: "https://fulcio.sigstage.dev"
+      fulcio_grpc_url: "grpc://fulcio.sigstage.dev"
       oidc_url: "https://oauth2.sigstage.dev/auth"
       tuf_repo: "https://tuf-repo-cdn.sigstage.dev"
       tuf_preprod_repo: "https://sigstore.github.io/root-signing-staging"

--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -17,6 +17,11 @@ on:
         type: string
         default: 'https://fulcio.sigstore.dev'
         description: 'Fulcio URL'
+      fulcio_grpc_url:
+        required: false
+        type: string
+        default: 'grpc://fulcio.sigstore.dev'
+        description: 'Fulcio GRPC URL'
       oidc_url:
         required: false
         type: string
@@ -95,7 +100,7 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 60
           retry_on: error
-          command: prober --one-time --rekor-url ${{ inputs.rekor_url }} --fulcio-url ${{ inputs.fulcio_url }}
+          command: prober --one-time --rekor-url ${{ inputs.rekor_url }} --fulcio-url ${{ inputs.fulcio_url }} --fulcio-grpc-url ${{ inputs.fulcio_grpc_url }}
 
       - name: Set messages
         id: msg


### PR DESCRIPTION


#### Summary
Add option for grpc_fulcio_url and set to the grpc://fulcio.sigstage.dev

During database migration it was noticed that the staging prober was failing, and it should not have been. We found it is referencing the prod endpoint (which was down due to maintenance) 
