### PR TITLE
Fix production sigstore GRPC probes

### DIFF
--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -20,7 +20,7 @@ on:
       fulcio_grpc_url:
         required: false
         type: string
-        default: 'grpc://fulcio.sigstore.dev'
+        default: 'fulcio.sigstore.dev'
         description: 'Fulcio GRPC URL'
       oidc_url:
         required: false


### PR DESCRIPTION

#### Summary

Applies the fix in https://github.com/sigstore/sigstore-probers/pull/278 to the `reusable-prober` default.

See https://github.com/sigstore/sigstore-probers/actions/runs/10762903903 for a sample failure.

#### Release Note

NONE

#### Documentation

N/A