### PR TITLE
Rekorv2 staging

### DIFF
--- a/.github/workflows/prober-staging.yml
+++ b/.github/workflows/prober-staging.yml
@@ -1,6 +1,7 @@
 name: Staging Sigstore Prober
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       triggerPagerDutyTest:

--- a/.github/workflows/prober-staging.yml
+++ b/.github/workflows/prober-staging.yml
@@ -26,6 +26,7 @@ jobs:
     with:
       enable_staging: true
       rekor_url: "https://rekor.sigstage.dev"
+      rekor_v2_url: "https://log2025-alpha1.rekor.sigstage.dev"
       fulcio_url: "https://fulcio.sigstage.dev"
       fulcio_grpc_url: "fulcio.sigstage.dev"
       tsa_url: "https://timestamp.sigstage.dev"

--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -12,6 +12,11 @@ on:
         type: string
         default: 'https://rekor.sigstore.dev'
         description: 'Rekor URL'
+      rekor_v2_url:
+        required: false
+        type: string
+        default: '' # TODO: no default while we do not yet have a production instance.
+        description: 'Rekor V2 URL'
       fulcio_url:
         required: false
         type: string
@@ -91,7 +96,7 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 60
           retry_on: error
-          command: prober --one-time --rekor-url ${{ inputs.rekor_url }} --fulcio-url ${{ inputs.fulcio_url }} --fulcio-grpc-url ${{ inputs.fulcio_grpc_url }} ${{ inputs.tsa_url != '' && format('--tsa-url {0}',inputs.tsa_url) || '' }}
+          command: prober --one-time --rekor-url ${{ inputs.rekor_url }} ${{ inputs.rekor_v2_url != '' && format('--rekor-v2-url {0}',inputs.rekor_v2_url) || '' }} --fulcio-url ${{ inputs.fulcio_url }} --fulcio-grpc-url ${{ inputs.fulcio_grpc_url }} ${{ inputs.tsa_url != '' && format('--tsa-url {0}',inputs.tsa_url) || '' }}
 
       - name: Set messages
         id: msg


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

https://github.com/sigstore/rekor-tiles/issues/46https://github.com/sigstore/rekor-tiles/issues/46

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Adds staging rekorv2 to the invocation of the probers, pending 

 - https://github.com/sigstore/scaffolding/pull/1616

Note: since the prober will auto-discover all shards via TUF, this PR may not be needed.

##### Followups

- [ ] add a production shard.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Adds staging rekorv2 to the invocation of the probers,

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
