### PR TITLE
Remove fsck build steps

### DIFF
--- a/.github/workflows/tiles-fsck.yml
+++ b/.github/workflows/tiles-fsck.yml
@@ -37,27 +37,12 @@ jobs:
           - staging
           # - production TODO: uncomment when key is published in root-signing
     steps:
-      # TODO: uncomment when image containing new tiles-fsck binary is published
-      #- name: Extract relevant binaries
-      #  run: |
-      #    docker pull ghcr.io/sigstore/sigstore-probers:latest
-      #    # the last argument in the next command is not used, it is required because the container doesn't have a default command
-      #    docker create --name binaries ghcr.io/sigstore/sigstore-probers /usr/local/bin/tiles-fsck
-      #    docker cp binaries:/usr/local/bin/tiles-fsck /usr/local/bin/
-
-      # TODO: remove build steps when new image is published
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          persist-credentials: false
-      - name: Set up Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
-        with:
-          go-version-file: 'go.work'
-          check-latest: true
-      - name: Build prober
+      - name: Extract relevant binaries
         run: |
-          go build ./prober/tiles-fsck/
-          mv tiles-fsck /usr/local/bin/
+          docker pull ghcr.io/sigstore/sigstore-probers:latest
+          # the last argument in the next command is not used, it is required because the container doesn't have a default command
+          docker create --name binaries ghcr.io/sigstore/sigstore-probers /usr/local/bin/tiles-fsck
+          docker cp binaries:/usr/local/bin/tiles-fsck /usr/local/bin/
 
       - name: Run Merkle Tree Consistency Check - ${{ matrix.url }}
         id: tiles_fsck


### PR DESCRIPTION
Use the published docker image instead of rebuilding the tool every time the cron job runs.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
