### PR TITLE
CODEOWNERS: move matches to same line

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @sigstore/sigstore-oncall
-* @sigstore/infrastructure-team
+* @sigstore/sigstore-oncall @sigstore/infrastructure-team


### PR DESCRIPTION
Only the last applicable match is actually used: these have to be on the same line.

