### PR TITLE
fix: Update e2e test result condition for GitHub Issue creation

### DIFF
--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -370,7 +370,7 @@ jobs:
         ]
 
   github-issue:
-    if: always() && (needs.sigstore-probe.result == 'failure' || needs.root-probe.result == 'failure' || needs.process-e2e-results.result == 'failure')
+    if: always() && (needs.sigstore-probe.result == 'failure' || needs.root-probe.result == 'failure' || needs.process-e2e-results.outputs.result == 'failure')
     runs-on: ubuntu-latest
     needs: [sigstore-probe, root-probe, rekor-fulcio-e2e, compute-summary-msg, process-e2e-results]
     permissions:


### PR DESCRIPTION
#### Summary

This change updates the condition that triggers the creation of a GitHub Issue in the event of a prober failure to use the correct Rekor/Fulcio e2e test result.