### PR TITLE
Rename sigstore-probers image

### DIFF
--- a/.github/workflows/build-publish-tools-container.yml
+++ b/.github/workflows/build-publish-tools-container.yml
@@ -22,7 +22,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ github.repository }}/tools
 
 permissions: {}
 

--- a/.github/workflows/ctlog-sth.yml
+++ b/.github/workflows/ctlog-sth.yml
@@ -42,9 +42,9 @@ jobs:
     steps:
       - name: Extract relevant binaries
         run: |
-          docker pull ghcr.io/sigstore/sigstore-probers:latest
+          docker pull ghcr.io/sigstore/sigstore-probers/tools:latest
           # the last argument in the next command is not used, it is required because the container doesn't have a default command
-          docker create --name binaries ghcr.io/sigstore/sigstore-probers /usr/local/bin/ctlog-sth
+          docker create --name binaries ghcr.io/sigstore/sigstore-probers/tools /usr/local/bin/ctlog-sth
           docker cp binaries:/usr/local/bin/ctlog-sth /usr/local/bin/
 
       - name: Probe CT log STH - ${{ matrix.env }} - ${{ matrix.shard }}

--- a/.github/workflows/rate-limiting.yml
+++ b/.github/workflows/rate-limiting.yml
@@ -29,9 +29,9 @@ jobs:
     steps:
       - name: Extract relevant binaries
         run: |
-          docker pull ghcr.io/sigstore/sigstore-probers:latest
+          docker pull ghcr.io/sigstore/sigstore-probers/tools:latest
           # the last argument in the next command is not used, it is required because the container doesn't have a default command
-          docker create --name binaries ghcr.io/sigstore/sigstore-probers /usr/local/bin/rate-limiting
+          docker create --name binaries ghcr.io/sigstore/sigstore-probers/tools /usr/local/bin/rate-limiting
           docker cp binaries:/usr/local/bin/rate-limiting /usr/local/bin/
 
       - name: Run Rate Limiting Prober for ${{ matrix.env }}

--- a/.github/workflows/reusable-pager.yml
+++ b/.github/workflows/reusable-pager.yml
@@ -54,9 +54,9 @@ jobs:
     steps:
       - name: Extract relevant binaries
         run: |
-          docker pull ghcr.io/sigstore/sigstore-probers:latest
+          docker pull ghcr.io/sigstore/sigstore-probers/tools:latest
           # the last argument in the next command is not used, it is required because the container doesn't have a default command
-          docker create --name binaries ghcr.io/sigstore/sigstore-probers /usr/local/bin/pager
+          docker create --name binaries ghcr.io/sigstore/sigstore-probers/tools /usr/local/bin/pager
           docker cp binaries:/usr/local/bin/pager /usr/local/bin/
 
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -53,9 +53,9 @@ jobs:
     steps:
       - name: Extract prober binary
         run: |
-          docker pull ghcr.io/sigstore/sigstore-probers:latest
+          docker pull ghcr.io/sigstore/sigstore-probers/tools:latest
           # the last argument in the next command is not used, it is required because the container doesn't have a default command
-          docker create --name binaries ghcr.io/sigstore/sigstore-probers /usr/local/bin/prober
+          docker create --name binaries ghcr.io/sigstore/sigstore-probers/tools /usr/local/bin/prober
           docker cp binaries:/usr/local/bin/prober /usr/local/bin/
 
       # Make sure rekor is up and we can get root info
@@ -163,9 +163,9 @@ jobs:
 
       - name: Extract relevant binaries
         run: |
-          docker pull ghcr.io/sigstore/sigstore-probers:latest
+          docker pull ghcr.io/sigstore/sigstore-probers/tools:latest
           # the last argument in the next command is not used, it is required because the container doesn't have a default command
-          docker create --name binaries ghcr.io/sigstore/sigstore-probers /usr/local/bin/crane
+          docker create --name binaries ghcr.io/sigstore/sigstore-probers/tools /usr/local/bin/crane
           docker cp binaries:/usr/local/bin/crane /usr/local/bin/
           docker cp binaries:/usr/local/bin/cosign /usr/local/bin/
 

--- a/.github/workflows/tiles-fsck.yml
+++ b/.github/workflows/tiles-fsck.yml
@@ -42,9 +42,9 @@ jobs:
     steps:
       - name: Extract relevant binaries
         run: |
-          docker pull ghcr.io/sigstore/sigstore-probers:latest
+          docker pull ghcr.io/sigstore/sigstore-probers/tools:latest
           # the last argument in the next command is not used, it is required because the container doesn't have a default command
-          docker create --name binaries ghcr.io/sigstore/sigstore-probers /usr/local/bin/tiles-fsck
+          docker create --name binaries ghcr.io/sigstore/sigstore-probers/tools /usr/local/bin/tiles-fsck
           docker cp binaries:/usr/local/bin/tiles-fsck /usr/local/bin/
 
       - name: Run Merkle Tree Consistency Check - ${{ matrix.url }}


### PR DESCRIPTION
The new prober-only image is namespaced under sigstore/sigstore-probers, so the multi-tool image should also be namespaced.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
