### PR TITLE
reusable prober: Make OIDC health check more robust

### DIFF
--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -151,7 +151,10 @@ jobs:
       - name: Confirm Github OIDC Server is Available
         continue-on-error: true
         run: |
-          curl -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" $ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore
+          curl \
+            --fail-with-body \
+            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore"
 
       # Since the server is down, we want to ignore the failure in this workflow
       # and skip paging PagerDuty


### PR DESCRIPTION
* Fail on HTTP error codes: curl by default returns 0 on http errors
* Avoid accidental shell forks by quoting URLs

Fixes #722 