### PR TITLE
Add high level retries to prober workflows

### DIFF
--- a/.github/workflows/prober-prod.yml
+++ b/.github/workflows/prober-prod.yml
@@ -3,7 +3,7 @@ name: Production Sigstore Prober
 on:
   workflow_dispatch:
     inputs:
-      triggerPagerDutyTest:
+      trigger_pager_duty_test:
         description: 'Trigger PagerDuty as a test'
         required: false
         type: boolean
@@ -33,8 +33,8 @@ jobs:
     secrets:
       PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
     with:
-      alertOnFailure: false
-      triggerPagerDutyTest: ${{ github.event.inputs.triggerPagerDutyTest }}
+      alert_on_failure: false
+      trigger_pager_duty_test: ${{ github.event.inputs.trigger_pager_duty_test }}
       tuf_repo: "https://tuf-repo-cdn.sigstore.dev"
       rekor_v2_url: ${{ github.event.inputs.rekor_v2_url }}
       rekor_v2_public_key: ${{ github.event.inputs.rekor_v2_public_key }}
@@ -60,8 +60,8 @@ jobs:
     secrets:
       PAGERDUTY_INTEGRATION_KEY: ${{ secrets.PAGERDUTY_INTEGRATION_KEY }}
     with:
-      alertOnFailure: true
-      triggerPagerDutyTest: ${{ github.event.inputs.triggerPagerDutyTest }}
+      alert_on_failure: true
+      trigger_pager_duty_test: ${{ github.event.inputs.trigger_pager_duty_test }}
       tuf_repo: "https://tuf-repo-cdn.sigstore.dev"
       rekor_v2_url: ${{ github.event.inputs.rekor_v2_url }}
       rekor_v2_public_key: ${{ github.event.inputs.rekor_v2_public_key }}

--- a/.github/workflows/prober-staging.yml
+++ b/.github/workflows/prober-staging.yml
@@ -3,7 +3,7 @@ name: Staging Sigstore Prober
 on:
   workflow_dispatch:
     inputs:
-      triggerPagerDutyTest:
+      trigger_pager_duty_test:
         description: 'Trigger PagerDuty as a test'
         required: false
         type: boolean
@@ -36,8 +36,8 @@ jobs:
       enable_staging: true
       tuf_repo: "https://tuf-repo-cdn.sigstage.dev"
       tuf_root_path: ".github/assets/sigstage.root.json"
-      alertOnFailure: false
-      triggerPagerDutyTest: ${{ github.event.inputs.triggerPagerDutyTest }}
+      alert_on_failure: false
+      trigger_pager_duty_test: ${{ github.event.inputs.trigger_pager_duty_test }}
       rekor_v2_url: ${{ github.event.inputs.rekor_v2_url }}
       rekor_v2_public_key: ${{ github.event.inputs.rekor_v2_public_key }}
 
@@ -65,7 +65,7 @@ jobs:
       enable_staging: true
       tuf_repo: "https://tuf-repo-cdn.sigstage.dev"
       tuf_root_path: ".github/assets/sigstage.root.json"
-      alertOnFailure: true
-      triggerPagerDutyTest: ${{ github.event.inputs.triggerPagerDutyTest }}
+      alert_on_failure: true
+      trigger_pager_duty_test: ${{ github.event.inputs.trigger_pager_duty_test }}
       rekor_v2_url: ${{ github.event.inputs.rekor_v2_url }}
       rekor_v2_public_key: ${{ github.event.inputs.rekor_v2_public_key }}

--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -27,12 +27,12 @@ on:
         type: string
         default: '.github/assets/sigstore.root.json'
         description: "path to the tuf root"
-      alertOnFailure:
+      alert_on_failure:
         description: 'If true, Use Pagerduty and GH Issues to alert on failure'
         required: false
         default: true
         type: boolean
-      triggerPagerDutyTest:
+      trigger_pager_duty_test:
         description: 'If true, trigger PagerDuty as a test'
         required: false
         type: boolean
@@ -332,7 +332,7 @@ jobs:
         id: msg
         if: success() || failure()
         run: |
-          if [ "${{ inputs.triggerPagerDutyTest }}" == "true" ]; then
+          if [ "${{ inputs.trigger_pager_duty_test }}" == "true" ]; then
             echo "summary=Test Notification" >> $GITHUB_OUTPUT
           else
             echo "summary=Prober Failed" >> $GITHUB_OUTPUT
@@ -343,7 +343,7 @@ jobs:
           fi
 
   pagerduty-notification:
-    if: inputs.triggerPagerDutyTest || (inputs.alertOnFailure && failure() && needs.process-e2e-results.outputs.skip_pagerduty != 'true')
+    if: inputs.trigger_pager_duty_test || (inputs.alert_on_failure && failure() && needs.process-e2e-results.outputs.skip_pagerduty != 'true')
     needs: [sigstore-probe, root-probe, rekor-fulcio-e2e, compute-summary-msg, process-e2e-results]
     uses: ./.github/workflows/reusable-pager.yml
     permissions:
@@ -378,7 +378,7 @@ jobs:
         ]
 
   github-issue:
-    if: always() && inputs.alertOnFailure && (needs.sigstore-probe.result == 'failure' || needs.root-probe.result == 'failure' || needs.process-e2e-results.outputs.result == 'failure')
+    if: always() && inputs.alert_on_failure && (needs.sigstore-probe.result == 'failure' || needs.root-probe.result == 'failure' || needs.process-e2e-results.outputs.result == 'failure')
     runs-on: ubuntu-latest
     needs: [sigstore-probe, root-probe, rekor-fulcio-e2e, compute-summary-msg, process-e2e-results]
     permissions:


### PR DESCRIPTION
## Changes 

Use a blunt instrument to deal with flakiness in the prober:
* Add an argument to reusable prober that allows caller to control if alerting (pager and issue filing) happens on failures or not
* In both prod and staging prober, run the reusable prober once (without alerting). If the initial prober run fails, wait 30secs and run the reusable prober again (now with alerting)
* Additionally, do some spring cleaning
  * consistent variable casing
  * make PagerDuty test variable make more sense: it's a boolean, not a message. A boolean variable should work just fine even in the bash injection cases
  * use `inputs` in reusable workflow, not `github.event.inputs`

Fixes #647 

## Self-review

* I don't know if this really helps: workflows rarely fail twice in a row and I hope that this applies to dispatching reusable prober twice in the same workflow
* This does make prod and staging prober a bit more complicated
* I don't expect a big effect on Actions runtime budget: Our failure rate is currently around 1% so this should add max 30 minutes runtime per month
* I expect paging latency to increase by ~1 minute but false positive page rate hopefully goes down significantly
* A notable side-effect is that workflow runs that fail the initial prober and then succeed on the second attempt are counted as failed in GitHub UI: there does not seem to be a way around this as `continue-on-error` cannot be used with reusable workflows