### PR TITLE
Retry prober on timeout and shorten timeout to 1 minute

### DIFF
--- a/.github/workflows/reusable-prober.yml
+++ b/.github/workflows/reusable-prober.yml
@@ -69,10 +69,10 @@ jobs:
           DEBUG: 1
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
-          timeout_minutes: 3
+          timeout_minutes: 1
           max_attempts: 3
           retry_wait_seconds: 60
-          retry_on: error
+          retry_on: any
           command: prober --one-time ${{ inputs.enable_staging && '--staging' || '' }}
 
       - name: Set messages


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

Closes: https://github.com/sigstore/sigstore-probers/issues/733

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This change:
   - Shortens `timeout_minutes` from 3 to 1 (p95 runtime is < 4 seconds, so 1 minute is generous)
   - Changes `retry_on` from `error` to `any` so that timeouts are retried


The `nick-fields/retry` action in the `reusable-prober.yml` workflow was configured to only retry on errors, not timeouts. If GitHub has connection issues it would time out without retry.

I was able to analyse actions workflow run  data for the prober in our data lake at GitHub. 90 day analysis shows 100% success rate for prober prod and prober staging. So rare that they time out

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

No documentaion update required
