### PR TITLE
dependabot: Fix docker group name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,7 +43,7 @@ updates:
     schedule:
       interval: "daily"
     groups:
-      actions:
+      docker:
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
PRs make a little more sense like this
